### PR TITLE
Descargar HostingBudler desde Winget en lugar de https

### DIFF
--- a/CreateLocalConfigFileForCSU.ps1
+++ b/CreateLocalConfigFileForCSU.ps1
@@ -7,7 +7,7 @@ $jsonFile = $result.ConfigFile
 $jsonBackupFile = $result.BackupFile
 
 # Cargar archivo
-$json = Get-Content $jsonFile | ConvertFrom-Json
+$json = Get-Content -Raw -Encoding utf8 $jsonFile | ConvertFrom-Json
 
 # Seteo de configuraciones obtenidas del entorno en caso de ser una VM DEV
 if (ExistsAosServiceFolder -and HasInstalledIIS) {
@@ -19,7 +19,7 @@ if (ExistsAosServiceFolder -and HasInstalledIIS) {
     $json.Thumbprint = GetWebSiteCertThumbprint("AOSService")
 } else {
     if ($null -ne $jsonBackupFile) {
-        $jsonBackup = Get-Content $jsonBackupFile | ConvertFrom-Json
+        $jsonBackup = Get-Content -Raw -Encoding utf8 $jsonBackupFile | ConvertFrom-Json
         # Versión anterior del json
         if ($null -ne $jsonBackup.EnvironmentId) {
             $json.EnvironmentId = $jsonBackup.EnvironmentId
@@ -38,7 +38,7 @@ if (ExistsAosServiceFolder -and HasInstalledIIS) {
 
 # Cargar archivo backup para recuperar algunas propiedades
 if ($null -ne $jsonBackupFile) {
-    $jsonBackup = Get-Content $jsonBackupFile | ConvertFrom-Json
+    $jsonBackup = Get-Content -Raw -Encoding utf8 $jsonBackupFile | ConvertFrom-Json
     
     # Versión anterior del json
     if ($null -ne $jsonBackup.ScaleUnitSetupPath) {
@@ -62,13 +62,13 @@ if ($null -ne $jsonBackupFile) {
         $json.CSUHttpPort = $jsonBackup.CSUHttpPort
     }
     
-    $json.TelemetryAppName = $jsonBackup.TelemetryAppName
-    $json.AppInsightsInstrumentationKey = $jsonBackup.AppInsightsInstrumentationKey
-    $json.RetailServerAadClientId = $jsonBackup.RetailServerAadClientId
-    $json.CposAadClientId = $jsonBackup.CposAadClientId
-    $json.AsyncClientAadClientId = $jsonBackup.AsyncClientAadClientId
-    $json.IntervalAsyncClient = $jsonBackup.IntervalAsyncClient
+        $json.TelemetryAppName = $jsonBackup.TelemetryAppName
+        $json.AppInsightsInstrumentationKey = $jsonBackup.AppInsightsInstrumentationKey
+        $json.RetailServerAadClientId = $jsonBackup.RetailServerAadClientId
+        $json.CposAadClientId = $jsonBackup.CposAadClientId
+        $json.AsyncClientAadClientId = $jsonBackup.AsyncClientAadClientId
+        $json.IntervalAsyncClient = $jsonBackup.IntervalAsyncClient
 }
 
 # Guardado del archivo
-$json | ConvertTo-Json | Out-File $jsonFile
+$json | ConvertTo-Json | Out-File -Encoding utf8 $jsonFile

--- a/CreateLocalConfigFileForHWS.ps1
+++ b/CreateLocalConfigFileForHWS.ps1
@@ -7,11 +7,11 @@ $jsonFile = $result.ConfigFile
 $jsonBackupFile = $result.BackupFile
 
 # Cargar archivo
-$json = Get-Content $jsonFile | ConvertFrom-Json
+$json = Get-Content -Raw -Encoding utf8 $jsonFile | ConvertFrom-Json
 
 # Cargar archivo backup para recuperar algunas propiedades
 if ($null -ne $jsonBackupFile) {
-    $jsonBackup = Get-Content $jsonBackupFile | ConvertFrom-Json
+    $jsonBackup = Get-Content -Raw -Encoding utf8 $jsonBackupFile | ConvertFrom-Json
     
     # Versión anterior del json HWS
     if ($null -ne $jsonBackup.HWSIsLocalCertificate) {
@@ -30,4 +30,4 @@ if ($null -ne $jsonBackupFile) {
 }
 
 # Guardado del archivo
-$json | ConvertTo-Json | Out-File $jsonFile
+$json | ConvertTo-Json | Out-File -Encoding utf8 $jsonFile

--- a/InstallCSU.ps1
+++ b/InstallCSU.ps1
@@ -33,9 +33,10 @@ if ($skipHostingBudle -eq $false) {
     # $url = "https://download.visualstudio.microsoft.com/download/pr/59c72253-7750-4f34-8804-4fb326754c4f/b83a6a459d49b6127757b4f873ba459f/dotnet-hosting-6.0.35-win.exe"
     # $HostingBudle = "Microsoft ASP.NET Core 8.0.11 Hosting Bundle Options"
     # $url = "https://download.visualstudio.microsoft.com/download/pr/4956ec5e-8502-4454-8f28-40239428820f/e7181890eed8dfa11cefbf817c4e86b0/dotnet-hosting-8.0.11-win.exe"
-    $HostingBudle = "Microsoft ASP.NET Core 8.0.15 Hosting Bundle Options"
-    $url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.15/dotnet-hosting-8.0.15-win.exe"
-    .\Support\CheckAndDownload.ps1 $HostingBudle $url 
+    # $HostingBudle = "Microsoft ASP.NET Core 8.0.15 Hosting Bundle Options"
+    # $url = "https://builds.dotnet.microsoft.com/dotnet/aspnetcore/Runtime/8.0.15/dotnet-hosting-8.0.15-win.exe"
+    # .\Support\CheckAndDownload.ps1 $HostingBudle $url 
+    winget install Microsoft.DotNet.HostingBundle.8
 }
 
 PrintFileName $MyInvocation.MyCommand.Name

--- a/PostInstall/ChangePosConfig.ps1
+++ b/PostInstall/ChangePosConfig.ps1
@@ -18,9 +18,9 @@ Set-Location $path
 Copy-Item "config.json" "config.json.backup"
 
 $jsonFile = "config.json"
-$json = Get-Content $jsonFile -Raw | ConvertFrom-Json
+$json = Get-Content $jsonFile -Raw -Encoding utf8 | ConvertFrom-Json
 $json.RetailServerUrl = $urlRetailServerCommerce
 
-$json | ConvertTo-Json -Compress -depth 32 | Out-File $jsonFile
+$json | ConvertTo-Json -Compress -depth 32 | Out-File -Encoding utf8 $jsonFile
 
 Set-Location $originalPath

--- a/Support/SupportFunctions.ps1
+++ b/Support/SupportFunctions.ps1
@@ -17,15 +17,29 @@ $isServerOS = Get-OSInfo
 
 if ($isServerOS) {
     # En Windows Server, usar el módulo WebAdministration
-    if (Get-Module -ListAvailable -Name WebAdministration) {
-        Import-Module WebAdministration
+    $hasWebAdmin = $null
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $hasWebAdmin = Get-Module -ListAvailable -Name WebAdministration -SkipEditionCheck
+    } else {
+        $hasWebAdmin = Get-Module -ListAvailable -Name WebAdministration
+    }
+
+    if ($hasWebAdmin) {
+        Import-Module WebAdministration -WarningAction SilentlyContinue
     } else {
         Write-Host -ForegroundColor Yellow "El módulo WebAdministration no está disponible. Algunas funciones pueden no estar operativas."
     }
 } else {
     # En Windows Cliente, usar el módulo IISAdministration si está disponible
-    if (Get-Module -ListAvailable -Name IISAdministration) {
-        Import-Module IISAdministration
+    $hasIISAdmin = $null
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $hasIISAdmin = Get-Module -ListAvailable -Name IISAdministration -SkipEditionCheck
+    } else {
+        $hasIISAdmin = Get-Module -ListAvailable -Name IISAdministration
+    }
+
+    if ($hasIISAdmin) {
+        Import-Module IISAdministration -WarningAction SilentlyContinue
     } else {
         Write-Host -ForegroundColor Yellow "El módulo IISAdministration no está disponible. Algunas funciones pueden no estar operativas."
     }
@@ -312,11 +326,13 @@ function New-LocalConfigFile {
     $jsonBackupFile = $null
     
     # Creo una copia de backup de existir una versión actual
-    $fileCount = (Get-ChildItem -Path $configFolder -Filter "$configFile*" -File | Measure-Object).Count
-    if ($fileCount -gt 0) {
-        $jsonBackupFile = "$configFile.BK$fileCount.json"
-        Rename-Item $jsonFile -NewName $jsonBackupFile
-        $jsonBackupFile = "$configFolder\$jsonBackupFile"
+    if (Test-Path -Path $jsonFile -PathType Leaf) {
+        $fileCount = (Get-ChildItem -Path $configFolder -Filter "$configFile*" -File | Measure-Object).Count
+        if ($fileCount -gt 0) {
+            $jsonBackupFile = "$configFile.BK$fileCount.json"
+            Rename-Item $jsonFile -NewName $jsonBackupFile
+            $jsonBackupFile = "$configFolder\$jsonBackupFile"
+        }
     }
 
     # Copy the sample file to the target file path
@@ -336,7 +352,7 @@ function Get-CSUParameters{
     )
 
     # Cargar el archivo JSON
-    $json = Get-Content $jsonFile -Raw | ConvertFrom-Json
+    $json = Get-Content $jsonFile -Raw -Encoding utf8 | ConvertFrom-Json
 
     return [PSCustomObject]@{
         SetupPath = $json.CSUSetupPath
@@ -360,7 +376,7 @@ function Get-HWSParameters{
     )
 
     # Cargar el archivo JSON
-    $json = Get-Content $jsonFile -Raw | ConvertFrom-Json
+    $json = Get-Content $jsonFile -Raw -Encoding utf8 | ConvertFrom-Json
 
     # Obtener los parámetros de configuración
     $setupPath = $json.HWSSetupPath


### PR DESCRIPTION
Se reemplaza la forma de descargar usando la URL de una versión estática de HostingBundle para pasar a usar `winget install Microsoft.DotNet.HostingBundle.8` dejando solamente el mayor version estático